### PR TITLE
Endpoint support

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -31,6 +31,7 @@ type dataSourceJsonModel struct {
 	ExternalID    string `json:"externalId"`
 	Profile       string `json:"profile"`
 	Region        string `json:"defaultRegion"`
+	Endpoint      string `json:"endpoint"`
 }
 
 type queryModel struct {
@@ -59,6 +60,7 @@ type CloudWatchAlarmDatasource struct {
 	authType      awsds.AuthType
 	assumeRoleARN string
 	externalID    string
+	endpoint      string
 	profile       string
 	region        string
 
@@ -99,6 +101,7 @@ func NewCloudWatchAlarmDatasource(sessions *awsds.SessionCache) datasource.Insta
 			authType:      parseAuthType(jsonData.AuthType),
 			assumeRoleARN: jsonData.AssumeRoleARN,
 			externalID:    jsonData.ExternalID,
+			endpoint  :    jsonData.Endpoint,
 			profile:       jsonData.Profile,
 			region:        jsonData.Region,
 
@@ -124,6 +127,7 @@ func (d *CloudWatchAlarmDatasource) newSession(region string) (*session.Session,
 			AuthType:      d.authType,
 			AssumeRoleARN: d.assumeRoleARN,
 			ExternalID:    d.externalID,
+			Endpoint:      d.endpoint,
 			DefaultRegion: d.region,
 			AccessKey:     d.accessKey,
 			SecretKey:     d.secretKey,

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -12,5 +12,5 @@ export const ConfigEditor: FC<Props> = (props) => {
     // todo: add warnings about invalid `authType`, just like:
     //       https://github.com/grafana/grafana/blob/23956557d8c6a119b7de5be5c42024e29634d002/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
 
-    return <ConnectionConfig options={options} onOptionsChange={onOptionsChange} skipEndpoint />;
+    return <ConnectionConfig options={options} onOptionsChange={onOptionsChange} />;
 };


### PR DESCRIPTION
This is a, what I hope is a simple, change to add endpoint support.

The AWS SDK for Go already supports this and it is utilised by the native cloudwatch metrics / logs datasources for grafana.

We have a use case whereby we proxy our cloudwatch requests via an API gateway, as cloudwatch has no support for fine grained access control on logs / metrics.

For the alarm use case, we want to filter out the auto scaling target tracking alarms at the proxy which the AWS describeAlarms does not allow you to do.

I'm not sure if these changes are complete. I could not see anywhere else in the code that would require changes, but I could not test locally as I could not get the GO plugin to compile.